### PR TITLE
Translate repository comments to English

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ PYTEST=$(VENV)/bin/pytest
 .PHONY: assure venv clean
 
 assure: venv
-	@$(PIP) install -e .
-	@$(PYTEST) -q
-	@echo "ASSURANCE OK — pipeline testado ponta a ponta."
+@$(PIP) install -e .
+@$(PYTEST) -q
+@echo "ASSURANCE OK - pipeline tested end to end."
 
 venv:
 	@test -d $(VENV) || python -m venv $(VENV)

--- a/examples/assurance_case.yaml
+++ b/examples/assurance_case.yaml
@@ -34,7 +34,7 @@ claims:
         prop: "brake_ready"
     evidence:
       - type: kripke_semantics
-        detail: "∀v in R_system(w0): brake_ready ∈ facts(v)"
+        detail: "forall v in R_system(w0): brake_ready in facts(v)"
   - id: C3
     type: epistemic
     spec:

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PY = sys.executable
 CLI = str(ROOT / "safety_protocol.py")
 SCHEMA = str(ROOT / "risk_note.schema.json")
-NOTE = str(ROOT / "risk-note-47.yaml")  # o repositório tem este arquivo na raiz
+NOTE = str(ROOT / "risk-note-47.yaml")  # the repository has this file at the root
 
 def run(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run([PY, CLI, *args], cwd=ROOT, text=True, capture_output=True)
@@ -21,10 +21,10 @@ def test_evidence_freshness_with_lenient_policy_passes():
 def test_generate_assurance_case_outputs_graph_text():
     cp = run("generate-assurance-case", NOTE)
     assert cp.returncode == 0, cp.stderr + cp.stdout
-    # README mostra um grafo com "Goal:" como prefixo do nó principal; checamos por isso.
+    # The README shows a graph with "Goal:" as the prefix of the main node; check for it.
     assert "Goal:" in cp.stdout or "Goal" in cp.stdout
 
 def test_prioritize_runs_with_budget_flag():
-    # O README demonstra "prioritize" com --budget horas ISO-8601; usamos o Risk Note existente. 
+    # The README demonstrates "prioritize" with --budget in ISO-8601 hours; we use the existing risk note.
     cp = run("prioritize", ".", "--budget", "PT40H")
     assert cp.returncode == 0, cp.stderr + cp.stdout

--- a/tests/test_posture_logic_unit.py
+++ b/tests/test_posture_logic_unit.py
@@ -2,10 +2,10 @@ from calculate_posture import calculate_posture
 
 
 def test_posture_logic_asymmetric_dominance():
-    # severidade alta domina
+    # high severity dominates
     assert calculate_posture(4, 3, 3) == "red"
-    # reversibilidade muito baixa também
-    assert calculate_posture(3, 2, 2) in ("amber","red")
-    # risco moderado cai em amber, baixo em green
-    assert calculate_posture(3, 2, 3) in ("amber","red")
+    # very low reversibility also dominates
+    assert calculate_posture(3, 2, 2) in ("amber", "red")
+    # moderate risk falls in amber, low in green
+    assert calculate_posture(3, 2, 3) in ("amber", "red")
     assert calculate_posture(1, 1, 4) == "green"


### PR DESCRIPTION
## Summary
- Translate comments and output messages into English across tests and Makefile
- Replace non-ASCII mathematical symbols in assurance case example

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1c729b534832fbd7286ea82a31f1f